### PR TITLE
Fix V3111, V3125 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/Server/Hotfix/Handler/G2G_LockRequestHandler.cs
+++ b/Server/Hotfix/Handler/G2G_LockRequestHandler.cs
@@ -12,15 +12,18 @@ namespace Hotfix
 			try
 			{
 				Unit unit = Game.Scene.GetComponent<UnitComponent>().Get(message.Id);
-				if (unit == null)
-				{
-					response.Error = ErrorCode.ERR_NotFoundUnit;
-					reply(response);
-				}
+                if (unit == null)
+                {
+                    response.Error = ErrorCode.ERR_NotFoundUnit;
+                    reply(response);
+                }
+                else
+                {
 
-				await unit.GetComponent<MasterComponent>().Lock(message.Address);
+                    await unit.GetComponent<MasterComponent>().Lock(message.Address);
 
-				reply(response);
+                    reply(response);
+                }
 			}
 			catch (Exception e)
 			{

--- a/Unity/Assets/Scripts/Base/DoubleMap.cs
+++ b/Unity/Assets/Scripts/Base/DoubleMap.cs
@@ -49,7 +49,7 @@ namespace Model
 
 		public void Add(K key, V value)
 		{
-			if (key == null || value == null || kv.ContainsKey(key) || vk.ContainsKey(value))
+			if (key == default(K) || value == default(V) || kv.ContainsKey(key) || vk.ContainsKey(value))
 			{
 				return;
 			}
@@ -59,7 +59,7 @@ namespace Model
 
 		public V GetValueByKey(K key)
 		{
-			if (key != null && kv.ContainsKey(key))
+			if (key != default(K) && kv.ContainsKey(key))
 			{
 				return kv[key];
 			}
@@ -68,7 +68,7 @@ namespace Model
 
 		public K GetKeyByValue(V value)
 		{
-			if (value != null && vk.ContainsKey(value))
+			if (value != default(V) && vk.ContainsKey(value))
 			{
 				return vk[value];
 			}
@@ -77,7 +77,7 @@ namespace Model
 
 		public void RemoveByKey(K key)
 		{
-			if (key == null)
+			if (key == default(K))
 			{
 				return;
 			}
@@ -93,7 +93,7 @@ namespace Model
 
 		public void RemoveByValue(V value)
 		{
-			if (value == null)
+			if (value == default(V))
 			{
 				return;
 			}
@@ -116,7 +116,7 @@ namespace Model
 
 		public bool ContainsKey(K key)
 		{
-			if (key == null)
+			if (key == default(K))
 			{
 				return false;
 			}
@@ -125,7 +125,7 @@ namespace Model
 
 		public bool ContainsValue(V value)
 		{
-			if (value == null)
+			if (value == default(V))
 			{
 				return false;
 			}
@@ -134,7 +134,7 @@ namespace Model
 
 		public bool Contains(K key, V value)
 		{
-			if (key == null || value == null)
+			if (key == default(K) || value == default(V))
 			{
 				return false;
 			}

--- a/Unity/Hotfix/Base/Message/AMHandler.cs
+++ b/Unity/Hotfix/Base/Message/AMHandler.cs
@@ -10,11 +10,14 @@ namespace Hotfix
 		public void Handle(AMessage msg)
 		{
 			Message message = msg as Message;
-			if (message == null)
-			{
-				Log.Error($"消息类型转换错误: {msg.GetType().Name} to {typeof(Message).Name}");
-			}
-			this.Run(message);
+            if (message == null)
+            {
+                Log.Error($"消息类型转换错误: {msg.GetType().Name} to {typeof(Message).Name}");
+            }
+            else
+            {
+                this.Run(message);
+            }
 		}
 
 		public Type GetMessageType()


### PR DESCRIPTION
Hello. I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

**About your warnings:** [V3111](https://www.viva64.com/en/w/v3111/), [V3125](https://www.viva64.com/en/w/v3125/).

### Warnings with low priority:

V3111 Checking value of 'key' for null will always return false when generic type is instantiated with a value type. DoubleMap.cs 52

V3111 Checking value of 'value' for null will always return false when generic type is instantiated with a value type. DoubleMap.cs 52

V3111 Checking value of 'key' for null will always return false when generic type is instantiated with a value type. DoubleMap.cs 62

V3111 Checking value of 'value' for null will always return false when generic type is instantiated with a value type. DoubleMap.cs 71

V3111 Checking value of 'key' for null will always return false when generic type is instantiated with a value type. DoubleMap.cs 80

V3111 Checking value of 'value' for null will always return false when generic type is instantiated with a value type. DoubleMap.cs 96

V3111 Checking value of 'key' for null will always return false when generic type is instantiated with a value type. DoubleMap.cs 119

V3111 Checking value of 'value' for null will always return false when generic type is instantiated with a value type. DoubleMap.cs 128

V3111 Checking value of 'key' for null will always return false when generic type is instantiated with a value type. DoubleMap.cs 137

V3111 Checking value of 'value' for null will always return false when generic type is instantiated with a value type. DoubleMap.cs 137

V3111 Checking value of 'message' for null will always return false when generic type is instantiated with a value type. AMHandler.cs 13

### Warning with medium priority:

V3125 The 'unit' object was used after it was verified against null. Check lines: 21, 15. G2G_LockRequestHandler.cs 21

